### PR TITLE
fix: a computer can be a touch device and still have a mouse

### DIFF
--- a/projects/ngx-panzoom/src/lib/panzoom.component.ts
+++ b/projects/ngx-panzoom/src/lib/panzoom.component.ts
@@ -221,17 +221,15 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy, PanZo
         if (this.isMobile) {
           this.frameElementRef().nativeElement.addEventListener('touchstart', this.onTouchStart);
         }
-        else {
-          this.frameElementRef().nativeElement.addEventListener('mousedown', this.onMouseDown);
-          this.frameElementRef().nativeElement.addEventListener('dblclick', this.onDblClick );
-          this.frameElementRef().nativeElement.addEventListener(
-            'wheel',
-            (event: WheelEvent) => this.animationFrameFunc(
-              () => this.onMouseWheel(event)
-            ),
-            { passive: true }
-          );
-        }
+        this.frameElementRef().nativeElement.addEventListener('mousedown', this.onMouseDown);
+        this.frameElementRef().nativeElement.addEventListener('dblclick', this.onDblClick );
+        this.frameElementRef().nativeElement.addEventListener(
+          'wheel',
+          (event: WheelEvent) => this.animationFrameFunc(
+            () => this.onMouseWheel(event)
+          ),
+          { passive: true }
+        );
 
       }
     );
@@ -242,17 +240,15 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy, PanZo
     if (this.isMobile) {
       this.frameElementRef().nativeElement.removeEventListener('touchstart', this.onTouchStart);
     }
-    else {
-      this.frameElementRef().nativeElement.removeEventListener('mousedown', this.onMouseDown);
-      this.frameElementRef().nativeElement.removeEventListener(
-        'wheel',
-        (event: WheelEvent) => this.animationFrameFunc(
-          () => this.onMouseWheel(event)
-        ),
-        { passive: true }
-      );
-      this.frameElementRef().nativeElement.removeEventListener('dblclick', this.onDblClick);
-    }
+    this.frameElementRef().nativeElement.removeEventListener('mousedown', this.onMouseDown);
+    this.frameElementRef().nativeElement.removeEventListener(
+      'wheel',
+      (event: WheelEvent) => this.animationFrameFunc(
+        () => this.onMouseWheel(event)
+      ),
+      { passive: true }
+    );
+    this.frameElementRef().nativeElement.removeEventListener('dblclick', this.onDblClick);
     if (this.animationId) {
       window.cancelAnimationFrame(this.animationId);
     }
@@ -352,10 +348,8 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy, PanZo
               document.addEventListener('touchend', this.onTouchEnd, false);
               document.addEventListener('touchmove', this.onTouchMove, { passive: true, capture: false })
             }
-            else {
-              document.addEventListener('mousemove', this.onMouseMove, { passive: true, capture: false });
-              document.addEventListener('mouseup', this.onMouseUp);
-            }
+            document.addEventListener('mousemove', this.onMouseMove, { passive: true, capture: false });
+            document.addEventListener('mouseup', this.onMouseUp);
           }
         ); // leave this on document
       }
@@ -562,18 +556,16 @@ export class PanZoomComponent implements OnInit, AfterViewInit, OnDestroy, PanZo
             { passive: true, capture: false } as EventListenerExtOptions
           );
         }
-        else {
-          document.removeEventListener(
-            'mousemove',
-            this.onMouseMove,
-            { passive: true, capture: false } as EventListenerExtOptions
-          );
-          document.removeEventListener(
-            'mouseup',
-            this.onMouseUp,
-            { passive: true } as EventListenerExtOptions
-          );
-        }
+        document.removeEventListener(
+          'mousemove',
+          this.onMouseMove,
+          { passive: true, capture: false } as EventListenerExtOptions
+        );
+        document.removeEventListener(
+          'mouseup',
+          this.onMouseUp,
+          { passive: true } as EventListenerExtOptions
+        );
       }
     );
     // Set the overlay to non-blocking again:


### PR DESCRIPTION
This resolves bug #71

A computer can be a touch device while having a mouse, so we should always register the mouse events, and only conditionally register the touch events